### PR TITLE
Use dist folder when building production package

### DIFF
--- a/src/main/scala/com/github/mmizutani/sbt/gulp/PlayGulpPlugin.scala
+++ b/src/main/scala/com/github/mmizutani/sbt/gulp/PlayGulpPlugin.scala
@@ -121,7 +121,7 @@ object PlayGulpPlugin extends AutoPlugin {
     clean <<= clean dependsOn gulpClean,
 
     // Add the views to the dist
-    unmanagedResourceDirectories in Assets <+= (gulpDirectory in Compile)(base => base / "src"),
+    unmanagedResourceDirectories in Assets <+= (gulpDirectory in Compile)(base => base / "dist"),
 
     // Add asset files in ui/src directory to the watch list for auto browser reloading
     watchSources <++= gulpDirectory map { path => ((path / "src") ** "*").get},


### PR DESCRIPTION
When doing sbt dist / stage "/dist" folder should be used rather than "/src"
