### PR TITLE
Rework gulp process handling (detect local gulp, fail on gulp build error)

### DIFF
--- a/src/main/scala/com/github/mmizutani/sbt/gulp/PlayGulpPlugin.scala
+++ b/src/main/scala/com/github/mmizutani/sbt/gulp/PlayGulpPlugin.scala
@@ -103,7 +103,7 @@ object PlayGulpPlugin extends AutoPlugin {
 
     // Add asset files in ui/src directory to the watch list for auto browser
     watchSources <++= gulpDirectory map { path => ((path / "src") ** "*.scala.*").get},
-  
+
     // Run gulp before sbt run
     playRunHooks <+= (gulpDirectory, gulpFile, forceGulp).map {
       (base, fileName, isForceEnabled) => GulpWatch(base, fileName, isForceEnabled)


### PR DESCRIPTION
If gulp is in the `package.json` dependencies (`node_modules` in UI
directory) then it is preferred over using the `$PATH` to resolve gulp.
This makes the gulp tasks "just work"™ after NPM install without
requiring the user to either install gulp globally or add the
`node_modules` to the path.