### PR TITLE
Feature/mitigate hook

### DIFF
--- a/src/main/scala/com/github/mmizutani/sbt/gulp/PlayGulpPlugin.scala
+++ b/src/main/scala/com/github/mmizutani/sbt/gulp/PlayGulpPlugin.scala
@@ -103,7 +103,7 @@ object PlayGulpPlugin extends AutoPlugin {
 
     // Add asset files in ui/src directory to the watch list for auto browser
     watchSources <++= gulpDirectory map { path => ((path / "src") ** "*.scala.*").get},
-  
+
     // Run gulp before sbt run
     playRunHooks <+= (gulpDirectory, gulpFile, forceGulp).map {
       (base, fileName, isForceEnabled) => GulpWatch(base, fileName, isForceEnabled)


### PR DESCRIPTION
Depends on #17 (and includes the changes from there) so you might want to merge #17 first and then this pull request in order to get a clean git history. If you merge #17 then this pull request should be a simple fast forward merge.

We are using play 2.5.8 and we noticed that during `sbt run` there are actually two gulp watch processes running. This results in all kinds of clusterfucks, for instance running gulp prettify concurrently will randomly destroy or truncate javascript files.
I am not sure why it happens at all (seems to be an issue in playframework as I can't find a problem with the PlayRunHook here - spoiler alert: it's not play but the README instructions, see below) but IMHO the plugin should prevent this from happening anyway.
I introduced a semaphore so that even if play tries to call the hook 42 times there will only ever be one gulp watch running.
