### PR TITLE
Make js tools run relative to gulpDirectory

### DIFF
--- a/src/main/scala/com/github/mmizutani/sbt/gulp/PlayGulpPlugin.scala
+++ b/src/main/scala/com/github/mmizutani/sbt/gulp/PlayGulpPlugin.scala
@@ -57,10 +57,16 @@ object PlayGulpPlugin extends AutoPlugin {
     commands <++= baseDirectory {
       base =>
         Seq(
-          "npm",
-          "bower",
           "yo",
           "git"
+        ).map(cmd(_, base))
+    }, 
+
+    commands <++= gulpDirectory {
+      base =>
+        Seq(
+          "npm",
+          "bower"
         ).map(cmd(_, base))
     },
 


### PR DESCRIPTION
JS tools need to be run inside `/ui` (or whaterver `gulpDirectory` is pointing at) to find their respective configuration files.

This change makes the instructions in the README work as expected and fixes #20