### PR TITLE
Drops content-disposition header

### DIFF
--- a/play-gulp/app/com/github/mmizutani/playgulp/GulpAssets.scala
+++ b/play-gulp/app/com/github/mmizutani/playgulp/GulpAssets.scala
@@ -7,8 +7,7 @@ import play.api.libs.MimeTypes
 import play.api.mvc._
 import java.io.File
 
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext, Future}
 import scala.collection.JavaConversions._
 
 import akka.stream.scaladsl.FileIO
@@ -16,7 +15,8 @@ import controllers.Assets
 
 @Singleton
 class GulpAssets @Inject() (env: play.api.Environment,
-                            conf: Configuration) extends Controller {
+                            conf: Configuration)
+                           (implicit val ec:ExecutionContext) extends Controller {
 
   private lazy val logger = Logger(getClass)
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,7 +7,7 @@
 //  "Typesafe repository" at "https://dl.bintray.com/typesafe/maven-releases/"
 //)
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.0")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.5.4")
 addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.3.0")
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.0")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")


### PR DESCRIPTION
The Content-Disposition header breaks the html import feature [1] which is
commonly used by web components frameworks such as polymer.
Therefore the `Ok.sendfile` helper is not appropriate for `GulpAssets` and
should be reserved to send over files to be downloaded
(whether forced downlading when disposition is attachment or providing a
filename for a preview when disposition is inline)

This commits drops `Ok.sendfile` in favor of `RangeResult.ofSource` which is the
method used by playframework's onw `Assets` controller.

[1] see https://www.w3.org/TR/html-imports/ and the following issues for the
rationale
 * https://bugs.chromium.org/p/chromium/issues/detail?id=439877
 * https://www.w3.org/Bugs/Public/show_bug.cgi?id=27550