### PR TITLE
Drops content-disposition header (based on enumeratee)

### DIFF
--- a/play-gulp/app/com/github/mmizutani/playgulp/GulpAssets.scala
+++ b/play-gulp/app/com/github/mmizutani/playgulp/GulpAssets.scala
@@ -10,14 +10,13 @@ import play.api.libs.iteratee.Execution.Implicits
 import play.api.libs.streams.Streams
 import play.api.mvc._
 import java.io.File
-import scala.concurrent.Future
-import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.{ExecutionContext,Future}
 import scala.collection.JavaConversions._
 import controllers.Assets
 
 @Singleton
 class GulpAssets @Inject() (env: play.api.Environment,
-                            conf: Configuration) extends Controller {
+                            conf: Configuration)(implicit val ec:ExecutionContext) extends Controller {
 
   private lazy val logger = Logger(getClass)
 


### PR DESCRIPTION
The Content-Disposition header breaks the html import feature [1] which is
commonly used by web components frameworks such as polymer.
Therefore the Ok.sendfile helper is not appropriate for GulpAssets and
should be reserved to send over files to be downloaded
(whether forced downlading when disposition is attachment or providing a
filename for a preview when disposition is inline)

This commits drops Ok.sendfile in favor of Ok.sendEntity which is the
method used by playframework's onw Assets controller.

This change is compatible with play 2.5.0 and upward.

[1] see https://www.w3.org/TR/html-imports/ and the following issues for the
rationale
 * https://bugs.chromium.org/p/chromium/issues/detail?id=439877
 * https://www.w3.org/Bugs/Public/show_bug.cgi?id=27550